### PR TITLE
Fix: Vercel 빌드 오류 해결

### DIFF
--- a/src/lib/hook/useUser.ts
+++ b/src/lib/hook/useUser.ts
@@ -1,1 +1,3 @@
 // https://github.com/vercel/next.js/blob/canary/examples/with-passport/lib/hooks.js
+
+export function useUser() {}


### PR DESCRIPTION

## 요약
비어있는 useUser.ts 파일로 인해 빌드 에러 발생 해결

## 변경사항
비어있는 함수를 추가해서 일단 에러 해결

## 참고 에러
Type error: 'useUser.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
